### PR TITLE
Prioritize Mari font over Mari Office

### DIFF
--- a/FONTS.md
+++ b/FONTS.md
@@ -6,8 +6,8 @@ BFHtheme pakken understøtter intelligent font-valg med automatisk fallback.
 
 Pakken prøver følgende skrifttyper i prioriteret rækkefølge:
 
-1. **Mari Office** (Primær) - BFH's officielle skrifttype
-2. **Mari** (Alternativ) - Alternativt navn
+1. **Mari** (Primær) - BFH's officielle skrifttype
+2. **Mari Office** (Alternativ) - Alternativt navn
 3. **Roboto** (Fallback) - Open source Google font
 4. **Arial** (Backup) - Universal fallback
 5. **sans** (System) - System default
@@ -52,19 +52,19 @@ Output:
 ```
 === BFH Font Availability ===
 
-Mari Office    : ✓ Available
 Mari           : ✗ Not found
+Mari Office    : ✓ Available
 Roboto         : ✓ Available
 Arial          : ✓ Available
 
-Recommended font: Mari Office
+Recommended font: Mari
 ```
 
 ## Mari Office Font
 
 **For BFH Medarbejdere:**
 
-Mari/Mari Office er BFH's officielle corporate font og er pre-installeret på alle medarbejder-computere. Ingen handling nødvendig - pakken vil automatisk bruge den.
+Mari Office/Mari er BFH's officielle corporate font og er pre-installeret på alle medarbejder-computere. Ingen handling nødvendig - pakken vil automatisk bruge den.
 
 **For Eksterne Brugere:**
 

--- a/R/fonts.R
+++ b/R/fonts.R
@@ -6,7 +6,7 @@
 #' @description
 #' Identifies the best available typeface for BFH-branded plots, caching the
 #' result to avoid repeated system queries. The priority order is:
-#' Mari/Mari Office → Roboto → Arial → sans.
+#' Mari → Mari Office → Roboto → Arial → sans.
 #'
 #' @details
 #' When `systemfonts` (preferred) or `extrafont` is installed the function checks
@@ -38,8 +38,8 @@ get_bfh_font <- function(check_installed = TRUE, silent = FALSE, force_refresh =
 
   # Font priority list
   fonts <- c(
-    "Mari",         # Primary BFH font (installed on employee PCs)
-    # "Mari Office",         # Alternative name
+    "Mari",         # Primary BFH font (preferred when available)
+    "Mari Office",  # Alternative/legacy name on some systems
     "Roboto",       # Open source fallback
     "Arial",        # Universal fallback
     "sans"          # System fallback
@@ -136,8 +136,8 @@ clear_bfh_font_cache <- function() {
 #' }
 check_bfh_fonts <- function() {
   fonts_to_check <- c(
-    "Mari Office" = "Mari Office",
     "Mari" = "Mari",
+    "Mari Office" = "Mari Office",
     "Roboto" = "Roboto",
     "Arial" = "Arial"
   )

--- a/man/get_bfh_font.Rd
+++ b/man/get_bfh_font.Rd
@@ -21,7 +21,7 @@ Character string containing the selected font family.
 \description{
 Identifies the best available typeface for BFH-branded plots, caching the
 result to avoid repeated system queries. The priority order is:
-Mari/Mari Office → Roboto → Arial → sans.
+Mari → Mari Office → Roboto → Arial → sans.
 }
 \details{
 When `systemfonts` (preferred) or `extrafont` is installed the function checks

--- a/tests/testthat/test-fonts.R
+++ b/tests/testthat/test-fonts.R
@@ -18,7 +18,22 @@ test_that("get_bfh_font returns a font when check_installed is TRUE", {
   expect_type(result, "character")
   expect_length(result, 1)
   # Should return one of the fallback fonts
-  expect_true(result %in% c("Mari", "Roboto", "Arial", "sans"))
+  expect_true(result %in% c("Mari", "Mari Office", "Roboto", "Arial", "sans"))
+})
+
+test_that("get_bfh_font prefers Mari when available", {
+  suppressMessages(clear_bfh_font_cache())
+
+  fake_fonts <- data.frame(family = c("Mari", "Mari Office", "Roboto"))
+
+  with_mocked_bindings(
+    requireNamespace = function(pkg, quietly = TRUE) pkg == "systemfonts",
+    `systemfonts::system_fonts` = function() fake_fonts,
+    {
+      result <- get_bfh_font(check_installed = TRUE, silent = TRUE, force_refresh = TRUE)
+      expect_equal(result, "Mari")
+    }
+  )
 })
 
 test_that("get_bfh_font silent parameter works", {
@@ -51,7 +66,7 @@ test_that("check_bfh_fonts returns logical vector", {
 test_that("check_bfh_fonts has named elements", {
   result <- suppressMessages(check_bfh_fonts())
   expect_named(result)
-  expected_names <- c("Mari Office", "Mari", "Roboto", "Arial")
+  expected_names <- c("Mari", "Mari Office", "Roboto", "Arial")
   expect_equal(names(result), expected_names)
 })
 


### PR DESCRIPTION
## Summary
- reorder the font priority helper to prefer Mari before Mari Office and adjust availability checks accordingly
- update the font usage documentation to describe the new Mari-first preference
- refresh unit tests to expect Mari when both Mari and Mari Office are available

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: Rscript is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee53307be08330ac264268d5170217