### PR TITLE
chore(release): bump version to 0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BFHtheme
 Type: Package
 Title: BFH Theme and Color Palettes for ggplot2
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: c(
     person(
       "Johan", "Reventlow",


### PR DESCRIPTION
## Summary

Release-prep commit. Bumper `DESCRIPTION Version` 0.5.0 -> 0.5.1 i forberedelse til develop -> main PR + `v0.5.1`-tag.

NEWS-entries for 0.5.1 allerede committet via tidligere PRs:
- font_available registry-fix (#73)
- test-hygiene (test-branding bruger withr)
- validation tightening (theme_bfh, bfh_save, add_bfh_footer base_size/family-validering)

## Test plan

- [x] DESCRIPTION Version: 0.5.0 -> 0.5.1
- [x] NEWS.md har komplet 0.5.1-sektion
- [ ] CI gron
- [ ] Merge til develop, derefter release-PR develop -> main + tag v0.5.1