### PR TITLE
chore(release): bump version to 0.5.2 (version-only)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BFHtheme
 Type: Package
 Title: BFH Theme and Color Palettes for ggplot2
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# BFHtheme 0.5.2
+
+## Interne ændringer
+
+* Version-bump uden funktionelle ændringer. Korrigerer et fejl-navngivet
+  `v0.5.2`-tag fra 0.5.1-release-flowet, hvor `DESCRIPTION`-version og NEWS
+  ikke blev bumpet. Indholdet er identisk med 0.5.1; denne release gør
+  `v0.5.2`-tagget gyldigt, så downstream-pakker kan deklarere
+  `BFHtheme (>= 0.5.2)`.
+
 # BFHtheme 0.5.1
 
 ## Breaking Changes


### PR DESCRIPTION
## Summary

- Bump `DESCRIPTION` Version 0.5.1 → 0.5.2 + NEWS-entry
- Version-only release: indhold identisk med 0.5.1
- Korrigerer fejl-navngivet `v0.5.2`-tag fra 0.5.1-release-flowet, hvor version/NEWS ikke blev bumpet, så `v0.5.2`-tagget pegede på Version 0.5.1
- Gør downstream lower-bound `BFHtheme (>= 0.5.2)` gyldig (blokerede biSPCharts Connect-manifest-validering)

## Test plan

- [x] `testthat::test_dir()` — ingen failures (indhold === released 0.5.1)
- [ ] Merge → develop
- [ ] Release-PR develop → main
- [ ] Force-retag `v0.5.2` til ny main-commit (Version 0.5.2)