### PR TITLE
release: BFHtheme 0.5.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BFHtheme
 Type: Package
 Title: BFH Theme and Color Palettes for ggplot2
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person(
       "Johan", "Reventlow",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# BFHtheme 0.5.2
+
+## Interne ændringer
+
+* Version-bump uden funktionelle ændringer. Korrigerer et fejl-navngivet
+  `v0.5.2`-tag fra 0.5.1-release-flowet, hvor `DESCRIPTION`-version og NEWS
+  ikke blev bumpet. Indholdet er identisk med 0.5.1; denne release gør
+  `v0.5.2`-tagget gyldigt, så downstream-pakker kan deklarere
+  `BFHtheme (>= 0.5.2)`.
+
 # BFHtheme 0.5.1
 
 ## Breaking Changes


### PR DESCRIPTION
## Summary

- Release develop → main for BFHtheme 0.5.2 (version-only)
- Indhold identisk med 0.5.1; bumper DESCRIPTION Version + NEWS
- Gør `v0.5.2`-tag gyldigt (korrigerer fejl-navngivet tag fra 0.5.1-flow)

## Test plan

- [x] testthat suite — ingen failures
- [ ] Merge → main, derefter force-retag v0.5.2 til ny main-HEAD